### PR TITLE
Add support for dict list fields like `tags` and `contributors`

### DIFF
--- a/feed2discord.examples.ini
+++ b/feed2discord.examples.ini
@@ -121,3 +121,11 @@ fields = **title**,*published*,link
 max_age = 86400
 feed_url = https://www.youtube.com/feeds/videos.xml?playlist_id=PLmX89YRYfWK2rUtmiKDg-R85FcRlLa8X4
 fields = **title**,*published*,*link*
+
+# shows the parsing of dict lists. Format is [delimiter]field.key
+[wccftech]
+channels = one
+feed_url = https://wccftech.com/feed/
+fields = **title**,description,"Tagged as",[ | ]tags.term,<link>
+filter_field = [|]tags.term
+one.filter = (?i)(amd|nvidia|intel)

--- a/feed2discord.py
+++ b/feed2discord.py
@@ -234,6 +234,7 @@ def process_field(field, item, FEED, channel):
     codematch = re.match('^`(.+)`$', field)
 
     tagmatch = re.match('^@(.+)$', field)  # new tag regex
+    dictmatch = re.match('^\[(.+)\](.+)\.(.+)$', field) # new dict regex
 
     if stringmatch is not None:
         # Return an actual string literal from config:
@@ -292,6 +293,17 @@ def process_field(field, item, FEED, channel):
                     "<@&%s>" % (role.id) if rn == str(i) else i for i in taglist
                 ]
                 return ", ".join(taglist)
+        else:
+            logger.error("process_field:%s:no such field", field)
+            return ""
+
+    elif dictmatch is not None:
+        logger.debug("%s:process_field:%s:isDict", FEED, field)
+        delim = dictmatch.group(1)
+        field = dictmatch.group(2)
+        dictkey = dictmatch.group(3)
+        if field in item:
+            return delim.join([x[dictkey] for x in item[field]])
         else:
             logger.error("process_field:%s:no such field", field)
             return ""

--- a/feed2discord.py
+++ b/feed2discord.py
@@ -653,7 +653,7 @@ def background_check_feed(conn, feed, asyncioloop):
                                     ' field ' +
                                     filter_field)
                                 regexmatch = re.search(
-                                    regexpat, item[filter_field])
+                                    regexpat, process_field(filter_field, item, FEED, channel))
                                 if regexmatch is None:
                                     include = False
                                     logger.info(
@@ -673,7 +673,7 @@ def background_check_feed(conn, feed, asyncioloop):
                                     item['title'] +
                                     ' field ' +
                                     filter_field)
-                                regexmatch = re.search(regexpat, item[filter_field])
+                                regexmatch = re.search(regexpat, process_field(filter_field, item, FEED, channel))
                                 if regexmatch is None:
                                     include = True
                                     logger.info(


### PR DESCRIPTION
Parse [tags](https://pythonhosted.org/feedparser/reference-entry-tags.html) and [contributors](https://pythonhosted.org/feedparser/reference-entry-contributors.html) fields and convert to string joined by a delimiter.

example output


**PUBG Mobile Uses Bots to Make You Think You’re Better at The Game Than You Are**
PlayerUnknown’s Battlegrounds is not an easy game. That’s part of the PUBG appeal, every chicken dinner has to be earned, but it can be a bit intimidating for new players. Well, it seems the newly-released mobile version of PUBG has found a way to ease newbies in – bots. A lot of players have noticed […]
The post PUBG Mobile Uses Bots to Make You Think You’re Better at The Game Than You Are by Nathan Birch appeared first on Wccftech.
Tagged as
Android | Console | Gaming | iOS | News | PC | Sticky | Xbox | playerunknown's battlegrounds | PUBG | PUBG Corp. | PUBG Mobile | Tencent