### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "feed2discord.py"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Discord RSS Bot](https://github.com/freiheit/discord_rss_bot)
 
 ![Feed Bot](avatars/avatar-angry-small.png)
-
+[![Run on Repl.it](https://repl.it/badge/github/freiheit/discord_feedbot)](https://repl.it/github/freiheit/discord_feedbot)
 Bot for taking in an RSS or Atom feed and sharing it into a Discord channel.
 
 Designed to be very configurable.


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@JacobWoods3/discordfeedbot).