### PR TITLE
Potential fix for code scanning alert no. 396: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/freiheit/discord_feedbot/security/code-scanning/396](https://github.com/freiheit/discord_feedbot/security/code-scanning/396)

To fix this, add an explicit `permissions` block in `.github/workflows/pylint.yml` with least-privilege access required for this workflow.

Best single fix without changing functionality:
- Add a workflow-level `permissions` block right after `on:` (or after `name:`/`on:` section) with:
  - `contents: read`
- This is sufficient for checkout and linting, and applies to all jobs unless overridden.

File/region to change:
- `.github/workflows/pylint.yml`, near the top of the file before `jobs:`.

No new imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
