### PR TITLE
refactor: dedupe helper scripts, trim dead wrappers and logging

### DIFF
--- a/feed2discord.py
+++ b/feed2discord.py
@@ -32,7 +32,6 @@ import feedfields
 
 from aiohttp.web_exceptions import HTTPError, HTTPNotModified
 from dateutil.parser import parse as parse_datetime
-from dateutil.tz import gettz
 
 __version__ = "4.2.0"
 
@@ -78,14 +77,14 @@ TZINFOS = {
     "UTC": timezone.utc,
     "GMT": timezone.utc,
     "Z": timezone.utc,
-    "EST": gettz("America/New_York"),
-    "EDT": gettz("America/New_York"),
-    "CST": gettz("America/Chicago"),
-    "CDT": gettz("America/Chicago"),
-    "MST": gettz("America/Denver"),
-    "MDT": gettz("America/Denver"),
-    "PST": gettz("America/Los_Angeles"),
-    "PDT": gettz("America/Los_Angeles"),
+    "EST": ZoneInfo("America/New_York"),
+    "EDT": ZoneInfo("America/New_York"),
+    "CST": ZoneInfo("America/Chicago"),
+    "CDT": ZoneInfo("America/Chicago"),
+    "MST": ZoneInfo("America/Denver"),
+    "MDT": ZoneInfo("America/Denver"),
+    "PST": ZoneInfo("America/Los_Angeles"),
+    "PDT": ZoneInfo("America/Los_Angeles"),
 }
 
 # HTTP statuses that mean "you're being rate-limited / the server is overloaded":
@@ -547,11 +546,6 @@ def _trim_leading_noise(text):
     return "\n\n".join(paras[i:])
 
 
-def _field_string(m):
-    """Return the literal string value from a "quoted" field spec. Called by process_field()."""
-    return m.group(1)
-
-
 def _field_highlight(m, item, FEED):
     """Return a field value wrapped in markup delimiters (bold, italic, spoiler, etc.). Called by process_field()."""
     begin, field, end = m.groups()
@@ -699,32 +693,22 @@ def process_field(field, item, FEED, channel):
             )
             return ""
 
-    logger.trace("%s:process_field:%s: checking regexes", FEED, field)
     if m := _RE_STRING.match(field):
-        logger.trace("%s:process_field:%s:isString", FEED, field)
-        return _field_string(m)
+        return m.group(1)
     if m := _RE_HIGHLIGHT.match(field):
-        logger.trace("%s:process_field:%s:isHighlight", FEED, field)
         return _field_highlight(m, item, FEED)
     if m := _RE_HEADER.match(field):
-        logger.trace("%s:process_field:%s:isHeader", FEED, field)
         return _field_header(m, item)
     if m := _RE_BIGCODE.match(field):
-        logger.trace("%s:process_field:%s:isCodeBlock", FEED, field)
         return _field_bigcode(m, item)
     if m := _RE_QUOTE.match(field):
-        logger.trace("%s:process_field:%s:isBlockquote", FEED, field)
         return _field_quote(m, item, FEED)
     if m := _RE_CODE.match(field):
-        logger.trace("%s:process_field:%s:isCode", FEED, field)
         return _field_code(m, item)
     if m := _RE_TAG.match(field):
-        logger.trace("%s:process_field:%s:isTag", FEED, field)
         return _field_tag(m, item, channel)
     if m := _RE_DICT.match(field):
-        logger.trace("%s:process_field:%s:isDict", FEED, field)
         return _field_dict(m, item)
-    logger.trace("%s:process_field:%s:isPlain", FEED, field)
     return _field_plain(field, item, FEED)
 
 

--- a/feedfields.py
+++ b/feedfields.py
@@ -28,6 +28,7 @@ import urllib.request
 import zlib
 from html.parser import HTMLParser
 
+import feedparser_rs as feedparser
 from html2text import HTML2Text
 
 
@@ -54,21 +55,15 @@ def http_get(url, user_agent, timeout=30):
         return (resp.status, resp.geturl(), body, resp.headers.get("Content-Type", ""))
 
 
-def make_html2text():
-    """Return an HTML2Text configured the way feed2discord renders body fields."""
-    h = HTML2Text()
-    h.ignore_links = True
-    h.ignore_images = True
-    h.ignore_emphasis = False
-    h.body_width = 1000
-    h.unicode_snob = True
-    h.ul_item_mark = "-"
-    return h
-
-
-# Shared instance: HTML2Text.handle() resets its output buffer each call, so the
-# object is stateless between uses and safe to reuse.
-_h2t = make_html2text()
+# Shared HTML2Text, configured the way feed2discord renders body fields.
+# handle() resets its output buffer each call, so reusing one instance is safe.
+_h2t = HTML2Text()
+_h2t.ignore_links = True
+_h2t.ignore_images = True
+_h2t.ignore_emphasis = False
+_h2t.body_width = 1000
+_h2t.unicode_snob = True
+_h2t.ul_item_mark = "-"
 
 
 def _is_mapping(obj):
@@ -373,3 +368,33 @@ def enumerate_fields(entry):
     for key, value in dict(entry).items():
         _collect(key, value, pairs)
     return pairs
+
+
+def fetch_feed(url, user_agent):
+    """Fetch url and parse it with feedparser_rs. Returns the parsed feed.
+
+    Shared by the discovery helpers (show_sample_entry.py, show_all_entries.py,
+    newfeed.py) so they fetch and parse exactly the way the bot does.
+    """
+    return feedparser.parse(http_get(url, user_agent)[2])
+
+
+def print_rendered(entry, truncate=None):
+    """Print every reachable field of an entry as ``=== token ===`` + value.
+
+    ``token`` is exactly what to drop into a feed's ``fields =`` line (including
+    dotted names like ``itunes.duration`` / ``enclosures.href``), so there's no
+    need to read the raw feed to figure out how to address a field.  When
+    ``truncate`` is set, long values are cut to that many characters.
+    """
+    for token, value, in_list in enumerate_fields(entry):
+        print(f"\n=== {token} ===")
+        if truncate is not None and len(value) > truncate:
+            print(value[:truncate])
+            print("... (truncated)")
+        else:
+            print(value)
+        if in_list:
+            print(
+                f"(list -- join all with e.g. [; ]{token}; delim can't contain a comma)"
+            )

--- a/newfeed.py
+++ b/newfeed.py
@@ -6,7 +6,6 @@
 # See README.md for instructions on setup and usage
 
 import discord
-import feedparser_rs as feedparser  # Rust parser: matches feed2discord
 import os
 import re
 import readline  # noqa: F401 -- imported for its side effect: input() line editing
@@ -14,31 +13,9 @@ import sys
 from configparser import ConfigParser
 from pathlib import Path
 
-from feedfields import enumerate_fields, http_get
+from feedfields import fetch_feed, print_rendered
 
 USER_AGENT = "linux:github.com/freiheit/discord_feedbot:newfeed.py (by /u/freiheit)"
-
-
-def print_rendered(entry):
-    """Print every reachable field as `=== token ===` + value (values truncated).
-
-    token is exactly what to drop into the `fields =` line below (including dotted
-    names like `itunes.duration` / `enclosures.href`), so you can build the field
-    list from what you see here without reading the raw feed.
-    """
-    for token, value, in_list in enumerate_fields(entry):
-        print(f"\n=== {token} ===")
-        print(value[:500])
-        if len(value) > 500:
-            print("... (truncated)")
-        if in_list:
-            print(
-                f"(list -- join all with e.g. [; ]{token}; delim can't contain a comma)"
-            )
-
-
-def fetch_feed(url):
-    return feedparser.parse(http_get(url, USER_AGENT)[2])
 
 
 # Get login_token from config:
@@ -79,11 +56,11 @@ if len(sys.argv) == 2:
 else:
     feed_url = input("Feed URL: ")
 
-feed_data = fetch_feed(feed_url)
+feed_data = fetch_feed(feed_url, USER_AGENT)
 if feed_data.entries:
     print("Latest feed item to help you figure out fields")
     print("----------")
-    print_rendered(feed_data.entries[0])
+    print_rendered(feed_data.entries[0], truncate=500)
     print("----------")
     print(
         "Recommend: try posting links in a room somewhere to see if discord gives a nice preview"

--- a/show_all_entries.py
+++ b/show_all_entries.py
@@ -5,42 +5,19 @@
 
 import sys
 
-import feedparser_rs as feedparser  # Rust parser: matches feed2discord
-
-from feedfields import enumerate_fields, http_get
+from feedfields import fetch_feed, print_rendered
 
 USER_AGENT = (
     "linux:github.com/freiheit/discord_feedbot:show_all_entries.py (by /u/freiheit)"
 )
 
 
-def print_rendered(entry):
-    """Print every reachable field as `=== token ===` + value (values truncated).
-
-    token is exactly what to drop into a feed's `fields =` line (including dotted
-    names like `itunes.duration` / `enclosures.href`).
-    """
-    for token, value, in_list in enumerate_fields(entry):
-        print(f"\n=== {token} ===")
-        print(value[:500])
-        if len(value) > 500:
-            print("... (truncated)")
-        if in_list:
-            print(
-                f"(list -- join all with e.g. [; ]{token}; delim can't contain a comma)"
-            )
-
-
-def fetch_feed(url):
-    return feedparser.parse(http_get(url, USER_AGENT)[2])
-
-
 # 0 is command itself:
 if len(sys.argv) == 2:
-    feed_data = fetch_feed(sys.argv[1])
+    feed_data = fetch_feed(sys.argv[1], USER_AGENT)
     for i, entry in enumerate(feed_data.entries):
         print(f"\n## Entry {i}:")
-        print_rendered(entry)
+        print_rendered(entry, truncate=500)
 else:
     print(
         "Give me 1 feed URL on the command-line, and I'll give all the entries from it."

--- a/show_sample_entry.py
+++ b/show_sample_entry.py
@@ -5,38 +5,16 @@
 
 import sys
 
-import feedparser_rs as feedparser  # Rust parser: matches feed2discord
-
-from feedfields import enumerate_fields, http_get
+from feedfields import fetch_feed, print_rendered
 
 USER_AGENT = (
     "linux:github.com/freiheit/discord_feedbot:show_sample_entry.py (by /u/freiheit)"
 )
 
 
-def print_rendered(entry):
-    """Print every reachable field as `=== token ===` + value.
-
-    token is exactly what to drop into a feed's `fields =` line (including dotted
-    names like `itunes.duration` / `enclosures.href`), so there's no need to read
-    the raw feed to figure out how to address a field.
-    """
-    for token, value, in_list in enumerate_fields(entry):
-        print(f"\n=== {token} ===")
-        print(value)
-        if in_list:
-            print(
-                f"(list -- join all with e.g. [; ]{token}; delim can't contain a comma)"
-            )
-
-
-def fetch_feed(url):
-    return feedparser.parse(http_get(url, USER_AGENT)[2])
-
-
 # 0 is command itself:
 if len(sys.argv) == 2:
-    feed_data = fetch_feed(sys.argv[1])
+    feed_data = fetch_feed(sys.argv[1], USER_AGENT)
     if not feed_data.entries:
         print("No entries in feed -- is that URL a working feed?")
         print("(version=%r bozo=%r)" % (feed_data.version, feed_data.bozo))


### PR DESCRIPTION
Follow-ups from the over-engineering audit, after #378 merged. Behavior-preserving; **brotli left in place on purpose** (still want to get it working eventually).

- **Dedupe helper scripts** — move the triplicated `fetch_feed()` and `print_rendered()` into `feedfields.py` (`print_rendered` gains a `truncate` arg). `show_all_entries.py`, `show_sample_entry.py`, and `newfeed.py` now just import them.
- **`process_field`** — drop the eight per-branch `logger.trace(...:isX)` lines; the entry trace plus the handler that runs already say which matched.
- **Inline `_field_string`** — its whole body was `return m.group(1)`.
- **`TZINFOS`** — replace `dateutil.tz.gettz` with stdlib `zoneinfo.ZoneInfo` (already imported). `dateutil` stays for lenient date parsing.
- **Inline `make_html2text()`** — one-caller factory folded into the module-level `_h2t`.

Net **−59 lines**. Compiles, pyflakes-clean, ruff pre-commit passing; smoke-tested `TZINFOS["PST"]`, body rendering, the shared helpers, and quoted-field dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)